### PR TITLE
fix: mitigate post process timeout

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,5 +15,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - run: docker run --rm -d -p 8983:8983 solr:9.1.0 solr-precreate example
-      - run: cargo test -- --include-ignored
+      - name: Launch solr instance from docker image for test
+        run: docker run --rm -d -p 8983:8983 --name solr_test solr:9.1.0 solr-precreate example
+      - name: Run all tests.
+        run: cargo test -- --include-ignored
+      - name: Stop solr instance
+        run: docker stop solr_test

--- a/solrust/Cargo.toml
+++ b/solrust/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 license = "Apache-2.0"
 name = "solrust"
 repository = "https://github.com/fjnkt98/solrust"
-version = "0.1.5"
+version = "0.1.6"
 
 [dependencies]
 chrono = {version = "^0.4", features = ["serde"]}

--- a/solrust/src/client/core.rs
+++ b/solrust/src/client/core.rs
@@ -182,7 +182,7 @@ impl SolrCore {
             .post(format!("{}/update", self.core_url))
             .header(CONTENT_TYPE, "application/json")
             .body(body)
-            .timeout(Duration::from_secs(3))
+            .timeout(Duration::from_secs(60))
             .send()
             .await
             .map_err(|e| SolrCoreError::RequestError(e))?;


### PR DESCRIPTION
POST processing is heavy,
so a timeout of 3 seconds would sometimes cause the process to fail.